### PR TITLE
adding engine to default to Node.js v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "serve-static": "^1.10.0",
     "vulcanize": "^1.10.3"
   },
+  "engines" : { "node" : "^4.0.0" },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve": "node serve.js",


### PR DESCRIPTION
I'm pushing for us to use Node.js v4.0.0 LTS from now on. Already catch some bugs in some of our deps for previous incompatibility issues (Node.js 0.10 vs 0.12 vs iojs) and now with v4.0.0 LTS everything is stabilizing and everyone is walking towards the same direction, solving weird problems.

Since there is no tests in the repo, I can't 100% verify it is Node.js v4.0.0 compatible, you should know how to fully tested better than I do. thanks :)
